### PR TITLE
Undefined names: np and torch

### DIFF
--- a/aion/embeddings/skip_thoughts.py
+++ b/aion/embeddings/skip_thoughts.py
@@ -14,6 +14,8 @@
 # ==============================================================================
 
 import os, datetime
+impport numpy as np
+import torch
 
 class SkipThoughtsEmbeddingsTorch:
     DICTIONARY_URL = "http://www.cs.toronto.edu/~rkiros/models/dictionary.txt"


### PR DESCRIPTION
flake8 testing of https://github.com/makcedward/nlp on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics___
```
./aion/embeddings/skip_thoughts.py:90:20: F821 undefined name 'UniSkip'
            return UniSkip(model_dir, words)
                   ^
./aion/embeddings/skip_thoughts.py:92:20: F821 undefined name 'BiSkip'
            return BiSkip(model_dir, words)
                   ^
./aion/embeddings/skip_thoughts.py:101:18: F821 undefined name 'Variable'
        inputs = Variable(LongTensor(transformed_sentences))
                 ^
./aion/embeddings/skip_thoughts.py:101:27: F821 undefined name 'LongTensor'
        inputs = Variable(LongTensor(transformed_sentences))
                          ^
./aion/embeddings/skip_thoughts.py:114:28: F821 undefined name 'skip_thoughts_emb'
            results.append(skip_thoughts_emb.predict(sentences=batch, output_format=output_format))
                           ^
./aion/embeddings/skip_thoughts.py:117:20: F821 undefined name 'np'
            return np.concatenate(results, axis=0)
                   ^
./aion/embeddings/skip_thoughts.py:119:20: F821 undefined name 'torch'
            return torch.cat(results, 0)                   ^
./aion/embeddings/infersent_lib/encoder/models.py:1:1: E999 SyntaxError: invalid syntax
../models.py^
1     E999 SyntaxError: invalid syntax
7     F821 undefined name 'UniSkip'
8
```